### PR TITLE
Fix - bump jq install version to 2.2.1

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -7,4 +7,4 @@ display:
   source_url: "https://github.com/SumoLogic/sumologic-orb"
 
 orbs:
-  jq: circleci/jq@2.2.0
+  jq: circleci/jq@2.2.1

--- a/src/examples/workflow-collector.yml
+++ b/src/examples/workflow-collector.yml
@@ -3,7 +3,7 @@ description: |
 usage:
     version: "2.1"
     orbs:
-        sumologic: sumologic/sumologic@2.1.0
+        sumologic: sumologic/sumologic@2.1.1
     jobs:
         build:
             docker:


### PR DESCRIPTION
Update the version of [jq/install](https://circleci.com/developer/orbs/orb/circleci/jq) to the newest patch release at 2.2.1

Fixes #10 